### PR TITLE
Fix SBCL (and others?)

### DIFF
--- a/process-two-way-stream.lisp
+++ b/process-two-way-stream.lisp
@@ -19,7 +19,7 @@
                                  :wait nil
                                  :search t)))
     (make-instance 'process-two-way-stream
-      :element-type '(unsigned-byte 8)
+      #+ALLEGRO :element-type #+ALLEGRO '(unsigned-byte 8)
       :input (process-info-output process)
       :output (process-info-input process)
       :process process)))


### PR DESCRIPTION
 Sorry, I should have tested before.

The :element-type arg added for Allegro CL causes invalid initialization argument in SBCL.

I fix this by guarding the addition by checking whether the system is Allegro CL.

Please let me know if there's a better way.

Thanks!