### PR TITLE
Make WITH-SMT work (on SBCL)

### DIFF
--- a/cl-smt-lib.lisp
+++ b/cl-smt-lib.lisp
@@ -86,7 +86,7 @@ case-sensitive smt libv2 format."
               (close (output ,smt))
               (let ((,status (wait-process (process ,smt))))
                 (unless (zerop ,status) (error "SMT solver failed with exit status ~S" ,status)))
-              (loop :for ,form = (read ,smt nil :eof)
+              (loop :for ,form = (read-from-smt ,smt t nil :eof)
                  :while (not (equal :eof ,form))
                  :collect ,form))
          ;; Ensure the process is terminated.

--- a/fundamental-two-way-stream.lisp
+++ b/fundamental-two-way-stream.lisp
@@ -1,6 +1,6 @@
 (defpackage :cl-smt-lib/fundamental-two-way-stream
   (:use :cl :trivial-gray-streams)
-  (:export :fundamental-two-way-stream))
+  (:export :fundamental-two-way-stream :input :output))
 (in-package :cl-smt-lib/fundamental-two-way-stream)
 
 (defclass fundamental-two-way-stream
@@ -12,7 +12,7 @@
 
 ;;; Trivial-gray-stream generic function customization.
 (defmethod stream-read-char ((stream fundamental-two-way-stream))
-  (read-char (input stream)))
+  (read-char (input stream) nil :eof))
 
 (defmethod stream-read-char-no-hang ((stream fundamental-two-way-stream))
   (read-char-no-hang (input stream)))

--- a/process-two-way-stream.lisp
+++ b/process-two-way-stream.lisp
@@ -1,7 +1,10 @@
 (defpackage :cl-smt-lib/process-two-way-stream
   (:use :cl :cl-smt-lib/fundamental-two-way-stream :uiop/launch-program)
   (:export :process-two-way-stream
-           :make-process-two-way-stream))
+           :make-process-two-way-stream
+           :input
+           :output
+           :process))
 (in-package :cl-smt-lib/process-two-way-stream)
 
 ;;; A process wrapped in a two-way stream.


### PR DESCRIPTION
Thank you for writing CL-SMT-LIB! This is great!

Commit message says it all:

> This change makes WITH-SMT work and detect solver errors e.g. if the specified solver is not installed. Tested on SBCL.
> 
> The previous behaviour was to always drop into the Lisp debugger, initially because the right OUTPUT symbol was not imported.

